### PR TITLE
android: Add wop_targets.xml for Halium 7.1 build

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,8 @@
 	revision="refs/heads/cm-14.1" />
 
   <default remote="aosp"
-           sync-j="6" />
+           sync-j="8" 
+           sync-c="true"/>
 
   <project path="abi/cpp" name="platform/abi/cpp" groups="pdk" remote="aosp" />
 

--- a/default.xml
+++ b/default.xml
@@ -37,6 +37,9 @@
   <project path="development" name="android_development" remote="los" />
 
   <project path="device/google/contexthub" name="device/google/contexthub" groups="device,marlin,pdk" remote="aosp" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" groups="qcom" remote="los" />
+  <project path="device/qcom/common" name="android_device_qcom_common" groups="qcom" remote="los" />
+  <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
@@ -51,6 +54,7 @@
   <project path="external/fec" name="platform/external/fec" groups="pdk" remote="aosp" />
   <project path="external/squashfs-tools" name="platform/external/squashfs-tools" groups="pdk" remote="aosp" />
   <project path="external/aac" name="android_external_aac" remote="los" groups="pdk" />
+  <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
   <project path="external/bison" name="platform/external/bison" groups="pdk" />
   <project path="external/bzip2" name="android_external_bzip2" remote="los" groups="pdk" />
   <project path="external/compiler-rt" name="Halium/android_external_compiler-rt" remote="hal" groups="pdk" />

--- a/default.xml
+++ b/default.xml
@@ -219,6 +219,7 @@
   <project path="prebuilts/tools" name="platform/prebuilts/tools" groups="pdk,tools" />
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" clone-depth="1" remote="aosp" />
   <project path="sdk" name="platform/sdk" groups="pdk-cw-fs" />
+  <project path="system/bt" name="android_system_bt" groups="pdk" remote="los" />
   <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" />
   <project path="system/extras" name="android_system_extras" groups="pdk" remote="los" />
   <project path="system/gatekeeper" name="platform/system/gatekeeper" groups="pdk" remote="aosp" />

--- a/default.xml
+++ b/default.xml
@@ -42,7 +42,7 @@
   <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
-  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" revision="cm-12.1 />
+  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" revision="cm-12.1" />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />

--- a/default.xml
+++ b/default.xml
@@ -42,6 +42,7 @@
   <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
+  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />

--- a/default.xml
+++ b/default.xml
@@ -43,7 +43,6 @@
   <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
-  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" revision="cm-12.1" />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />

--- a/default.xml
+++ b/default.xml
@@ -42,7 +42,7 @@
   <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
-  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" />
+  <project path="external/bluetooth/bluedroid" name="android_external_bluetooth_bluedroid" remote="los" revision="cm-12.1 />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -18,8 +18,15 @@
   
   <!-- TheMuppets vendor for Xiaomi -->
   <project path="vendor/xiaomi" name="TheMuppets/proprietary_vendor_xiaomi" remote="Github" revision="cm-14.1"/>
+  <!-- TheMuppets vendor for OnePlus -->
+  <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
+
   <!-- Halium 7.1 Xiaomi Mido -->
   <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
   <project path="kernel/xiaomi/msm8953" name="piggz/android_kernel_xiaomi_msm8953" remote="Github" revision="pgz-14.1-eb8"/>
-  
+
+ <!-- Halium 7.1 OnePlus Onyx -->
+  <project path="device/oneplus/onyx" name="lineageos/android_device_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+  <project path="kernel/oneplus/onyx" name="lineageos/android_kernel_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+   
 </manifest>

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remove-project name="Halium/hybris-boot" />
+
+  <remote  name="webos-ports"
+           fetch="git://github.com/webOS-ports/"
+           revision="halium-7.1"/>
+           
+  <remote  name="Github"
+           fetch="git://github.com/"/>
+
+  <!-- system/core: do our own tweaks of init.rc
+  <remove-project name="mer-hybris/android_system_core" />
+  <project path="system/core" name="webOS-ports/android_system_core" groups="pdk" revision="wop-12.1"/>
+ -->
+  <!-- luneos/luneos-hal: contain patches to apply before starting the build. -->
+  <project path="luneos/luneos-hal" name="android_luneos_hal" remote="webos-ports" revision="halium-7.1"/>
+  
+  <!-- TheMuppets vendor for Xiaomi -->
+  <project path="vendor/xiaomi" name="TheMuppets/proprietary_vendor_xiaomi" remote="Github" revision="cm-14.1"/>
+  <!-- Halium 7.1 Xiaomi Mido -->
+  <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
+  <project path="kernel/xiaomi/msm8953" name="piggz/android_kernel_xiaomi_msm8953" remote="Github" revision="pgz-14.1-eb8"/>
+  
+</manifest>

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -21,7 +21,7 @@
   <!-- TheMuppets vendor for OnePlus -->
   <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
   <!-- TheMuppets vendor for Motorola -->
-  <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_motorola" remote="Github" revision="cm-14.1"/>
+  <project path="vendor/motorola" name="TheMuppets/proprietary_vendor_motorola" remote="Github" revision="cm-14.1"/>
 
   <!-- Halium 7.1 Xiaomi Mido -->
   <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -20,16 +20,22 @@
   <project path="vendor/xiaomi" name="TheMuppets/proprietary_vendor_xiaomi" remote="Github" revision="cm-14.1"/>
   <!-- TheMuppets vendor for OnePlus -->
   <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
+  <!-- TheMuppets vendor for Motorola -->
+  <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
 
   <!-- Halium 7.1 Xiaomi Mido -->
   <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
   <project path="kernel/xiaomi/msm8953" name="piggz/android_kernel_xiaomi_msm8953" remote="Github" revision="pgz-14.1-eb8"/>
 
- <!-- Halium 7.1 OnePlus Onyx -->
+  <!-- Halium 7.1 OnePlus Onyx -->
   <project path="device/oneplus/onyx" name="lineageos/android_device_oneplus_onyx" remote="Github" revision="cm-14.1"/>
   <project path="kernel/oneplus/onyx" name="lineageos/android_kernel_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+
+  <!-- Halium 7.1 Motorola G4 -->
+  <project path="device/motorola/athene" name="lineageos/android_device_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+  <project path="kernel/motorola/msm8952" name="lineageos/android_kernel_motorola_msm8952" remote="Github" revision="cm-14.1"/>
   
- <!--Seeing that OnePlus is a daughter company of Oppo, it seems it uses some of it's technical bits, so we include these there too -->
+  <!-- Seeing that OnePlus is a daughter company of Oppo, it seems it uses some of it's technical bits, so we include these there too -->
   <project path="device/oppo/common" name="lineageos/android_device_oppo_common" remote="Github" revision="cm-14.1"/>
    
 </manifest>

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -28,5 +28,8 @@
  <!-- Halium 7.1 OnePlus Onyx -->
   <project path="device/oneplus/onyx" name="lineageos/android_device_oneplus_onyx" remote="Github" revision="cm-14.1"/>
   <project path="kernel/oneplus/onyx" name="lineageos/android_kernel_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+  
+ <!--Seeing that OnePlus is a daughter company of Oppo, it seems it uses some of it's technical bits, so we include these there too -->
+  <project path="device/oppo/common" name="lineageos/android_device_oppo_common" remote="Github" revision="cm-14.1"/>
    
 </manifest>

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -32,7 +32,7 @@
   <project path="kernel/oneplus/onyx" name="lineageos/android_kernel_oneplus_onyx" remote="Github" revision="cm-14.1"/>
 
   <!-- Halium 7.1 Motorola G4 -->
-  <project path="device/motorola/athene" name="lineageos/android_device_oneplus_onyx" remote="Github" revision="cm-14.1"/>
+  <project path="device/motorola/athene" name="lineageos/android_device_motorola_athene" remote="Github" revision="cm-14.1"/>
   <project path="kernel/motorola/msm8952" name="lineageos/android_kernel_motorola_msm8952" remote="Github" revision="cm-14.1"/>
   
   <!-- Seeing that OnePlus is a daughter company of Oppo, it seems it uses some of it's technical bits, so we include these there too -->

--- a/wop_targets.xml
+++ b/wop_targets.xml
@@ -21,7 +21,7 @@
   <!-- TheMuppets vendor for OnePlus -->
   <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
   <!-- TheMuppets vendor for Motorola -->
-  <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
+  <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_motorola" remote="Github" revision="cm-14.1"/>
 
   <!-- Halium 7.1 Xiaomi Mido -->
   <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>


### PR DESCRIPTION
-For Xiaomi Redmi Note 4 (mido) as initial target.

wop_targets.xml: Add vendor/xiaomi, device/xiaomi/mido, kernel/xiaomi/msm8953.
default.xml: Add device/qcom/sepolicy, device/qcom/common,
vendor/qcom/opensource/cryptfs_hw,
external/ant-wireless/antradio-library

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>